### PR TITLE
Feature/channels

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -11,7 +11,7 @@
 CC		= gcc
 NAME		= server
 BUILD_PATH	= obj
-SRC		= src/server.c src/main.c src/clients_list.c  src/command.c \
+SRC		= src/server.c src/main.c src/clients_list.c  src/command.c  src/channel.c \
 			../common/libmy.c ../common/color.c ../common/display.c 
 OBJ		= $(SRC:%.c=%.o)
 INCLUDES	= -I ../includes -I ./includes

--- a/server/config
+++ b/server/config
@@ -1,2 +1,3 @@
 port:12345
 max_clients:4
+channels:General,Random

--- a/server/includes/channel.h
+++ b/server/includes/channel.h
@@ -1,0 +1,21 @@
+#ifndef __CHANNEL_H__
+#define __CHANNEL_H__
+
+#include "includes_server.h"
+
+typedef struct s_channel
+{
+	char 				*name;
+	struct s_channel 	*next;
+	struct s_channel 	*prev;
+} t_channel;
+
+typedef struct s_channels_list
+{
+	t_channel 	*first_channel;
+	t_channel	*last_channel;
+} t_channels_list;
+
+t_channels_list *new_channels_list();
+
+#endif

--- a/server/includes/client.h
+++ b/server/includes/client.h
@@ -11,6 +11,7 @@ typedef struct s_client
     struct s_client 			*prev;
     struct s_client 			*next;
     char                        nickname[NICKNAME_MAX_LEN];
+    struct s_channel 			*current_channel;
 } t_client;
 
 #endif

--- a/server/includes/command.h
+++ b/server/includes/command.h
@@ -18,5 +18,12 @@ void list_commands(t_server *server, t_client *client, char **splitted_message);
 void direct_message(t_server *server, t_client *client, char **splitted_message);
 void send_direct_message(t_client *client, int target, char *message);
 void help(t_server *server, t_client *client, char **splitted_message);
+void list_channels(t_server *server, t_client *client, char **splitted_message);
+void join(t_server *server, t_client *client, char **splitted_message);
+void leave(t_server *server, t_client *client, char **splitted_message);
+int check_channel_availability(t_server *server, char *name);
+void create(t_server *server, t_client *client, char **splitted_message);
+void notify_channel(t_server *server, t_client *client, char *action);
+void ping(t_server *server, t_client *client, char **splitted_message);
 
 #endif

--- a/server/includes/includes_server.h
+++ b/server/includes/includes_server.h
@@ -17,5 +17,6 @@
 #include "display.h"
 #include "libmy.h"
 #include "command.h"
+#include "channel.h"
 
 #endif

--- a/server/includes/server.h
+++ b/server/includes/server.h
@@ -2,12 +2,13 @@
 #define __SERVER_H__
 
 #include "includes_server.h"
-
+#include "channel.h"
 
 typedef struct s_config
 {
-	uint port;
-	uint max_clients;
+	uint 				port;
+	uint 				max_clients;
+	t_channels_list		*channels_list;
 } t_config;
 
 typedef struct s_server
@@ -32,5 +33,8 @@ void remove_client_from_list(t_server *server, t_client *client);
 void disconnect(t_server *server, t_client *client);
 int check_nickname(t_server *server, t_client *client);
 t_config *get_config(char *path);
+void add_channel(t_channels_list *channels_list, char *name);
+t_channels_list *get_channels_list(char *channels);
+t_channel *get_channel(t_server *server, char *name);
 
 #endif

--- a/server/src/channel.c
+++ b/server/src/channel.c
@@ -1,0 +1,22 @@
+#include "includes_server.h"
+
+t_channels_list *new_channels_list()
+{
+	t_channels_list *channels;
+	t_channel 		*main_channel;
+
+	channels = malloc(sizeof(t_channels_list));
+	if (channels == NULL)
+	{
+		return (NULL);
+	}
+	main_channel = malloc(sizeof(t_channel));
+	if (main_channel == NULL)
+	{
+		return (NULL);
+	}
+	main_channel->name = my_strdup("General");
+	channels->first_channel = main_channel;
+	channels->last_channel = main_channel;
+	return (channels);
+}


### PR DESCRIPTION
Add channels implementation with all associated commands (join/leave/list) and some more (create)
Add ping command which was probably the hardest part of the work
Channels can be specified in the config file. (default creates only one named "General")

This closes #61, closes #70 , closes #69 (using join command),  closes #68 (idem), closes #67 (see below), closes #66 , closes #65 , closes #64 , #17 , closes #14 , closes #13 , closes #12 , closes #11, closes #10 

About issue #67 : In order to avoir circular references the channel does not hold a reference to each of its clients. Since we are manipulating clients structures most of the time it was preferable to make the client hold a reference on its channel. We then apply a filter on our linked list of clients in order to get the right users for the right channels.