### PR TITLE
Fix/list commands

### DIFF
--- a/server/src/command.c
+++ b/server/src/command.c
@@ -87,11 +87,10 @@ void list_commands(t_server *server, t_client *client, char **splitted_message)
 
     i = 0;
     len = my_strlen("List of all server commands :\n");
-    all_commands = malloc(len);
     all_commands = my_strdup("List of all server commands :\n");
     while ((current_command = server_command_array[i]).command != NULL)
     {
-        len += my_strlen(current_command.command) + my_strlen(current_command.description) + 7;
+        len += my_strlen(current_command.command) + my_strlen(current_command.description) + 8;
         all_commands = realloc(all_commands, len);
         my_strcat(all_commands, "\t- ");
         my_strcat(all_commands, current_command.command);


### PR DESCRIPTION
Had a malloc error on list_commands.
Turned out we weren't reallocating enough memory for our char array (omitting '\n' ?) add 1 to buffer and everything works fine.